### PR TITLE
feat: add embeddable widgets and flexible PNG exports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,10 +157,11 @@ function App() {
       .finally(() => setIsDownloading(false));
   }, []);
 
-  const handleDownloadCombo = useCallback((index, style = comboExportStyle) => {
+  const handleDownloadCombo = useCallback((index, style) => {
+    const resolvedStyle = style ?? comboExportStyle;
     flushSync(() => {
       setExportComboIndex(index);
-      setComboExportStyle(style);
+      setComboExportStyle(resolvedStyle);
       setIsDownloading(true);
     });
     if (!exportRef.current) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,9 +143,16 @@ function App() {
     return () => window.removeEventListener('click', close);
   }, [showDeckStyleMenu, showComboStyleMenu]);
 
-  const handleDownloadDeck = useCallback(() => {
-    if (!exportRef.current) return;
-    setIsDownloading(true);
+  const handleDownloadDeck = useCallback((style) => {
+    const resolvedStyle = style ?? deckExportStyle;
+    flushSync(() => {
+      setDeckExportStyle(resolvedStyle);
+      setIsDownloading(true);
+    });
+    if (!exportRef.current) {
+      setIsDownloading(false);
+      return;
+    }
     toPng(exportRef.current, { cacheBust: true, backgroundColor: '#080c18' })
       .then((dataUrl) => {
         const a = document.createElement('a');
@@ -155,7 +162,7 @@ function App() {
       })
       .catch(() => setDownloadError('Download failed. Try again.'))
       .finally(() => setIsDownloading(false));
-  }, []);
+  }, [deckExportStyle]);
 
   const handleDownloadCombo = useCallback((index, style) => {
     const resolvedStyle = style ?? comboExportStyle;
@@ -625,7 +632,7 @@ function App() {
                     { id: 'compact-image', label: 'Compact with Image', desc: 'Small image + bars' },
                   ].map(({ id, label, desc }) => (
                     <button key={id}
-                      onClick={() => { setDeckExportStyle(id); setShowDeckStyleMenu(false); }}
+                      onClick={() => { setShowDeckStyleMenu(false); handleDownloadDeck(id); }}
                       style={{
                         display: 'flex', alignItems: 'center', gap: '10px',
                         width: '100%', padding: '9px 14px', textAlign: 'left',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,12 @@ import PartSelector from './PartSelector';
 import ModeToggle from './ModeToggle';
 import Beyblade from './Beyblade';
 import ComboSummaryList from './components/ComboSummaryList';
-import ExportCard from './components/ExportCard';
 import SupportPopup from './components/SupportPopup';
+import ShareModal from './components/ShareModal';
+import DeckWidget from './components/widgets/DeckWidget';
+import SingleComboWidget from './components/widgets/SingleComboWidget';
+import CompactListWidget from './components/widgets/CompactListWidget';
+import CompactImageWidget from './components/widgets/CompactImageWidget';
 import { shouldShowSupportPopup } from './lib/supportPopup';
 import { useBeybladeDeck } from './hooks/useBeybladeDeck';
 
@@ -97,7 +101,6 @@ function App() {
     partsUsed,
     totalPoints,
     handlePartChange,
-    handleShareButton,
     handleRandomizeAll,
     handleRandomizeSingle,
   } = useBeybladeDeck();
@@ -121,12 +124,24 @@ function App() {
   const [exportComboIndex, setExportComboIndex] = useState(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState(null);
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [deckExportStyle, setDeckExportStyle] = useState('deck');
+  const [showDeckStyleMenu, setShowDeckStyleMenu] = useState(false);
+  const [comboExportStyle, setComboExportStyle] = useState('single');
+  const [showComboStyleMenu, setShowComboStyleMenu] = useState(null);
 
   useEffect(() => {
     if (!downloadError) return;
     const t = setTimeout(() => setDownloadError(null), 4000);
     return () => clearTimeout(t);
   }, [downloadError]);
+
+  useEffect(() => {
+    if (!showDeckStyleMenu && showComboStyleMenu === null) return;
+    const close = () => { setShowDeckStyleMenu(false); setShowComboStyleMenu(null); };
+    window.addEventListener('click', close);
+    return () => window.removeEventListener('click', close);
+  }, [showDeckStyleMenu, showComboStyleMenu]);
 
   const handleDownloadDeck = useCallback(() => {
     if (!exportRef.current) return;
@@ -142,9 +157,10 @@ function App() {
       .finally(() => setIsDownloading(false));
   }, []);
 
-  const handleDownloadCombo = useCallback((index) => {
+  const handleDownloadCombo = useCallback((index, style = comboExportStyle) => {
     flushSync(() => {
       setExportComboIndex(index);
+      setComboExportStyle(style);
       setIsDownloading(true);
     });
     if (!exportRef.current) {
@@ -164,7 +180,7 @@ function App() {
         setExportComboIndex(null);
         setIsDownloading(false);
       });
-  }, []);
+  }, [comboExportStyle]);
 
   return (
     <div className="min-h-screen px-4 pb-12" style={{ background: 'var(--color-bg)', fontFamily: 'var(--font-body)' }}>
@@ -363,22 +379,75 @@ function App() {
                       <IconRandomize small />
                       Randomize
                     </button>
-                    <button
-                      onClick={() => handleDownloadCombo(index)}
-                      disabled={exportComboIndex !== null || isDownloading}
-                      title="Download this combo"
-                      aria-label={`Download combo ${index + 1}`}
-                      className="flex items-center justify-center w-7 h-7 rounded transition-all hover:brightness-110"
-                      style={{
-                        background: 'var(--color-accent-dim)',
-                        border: '1px solid rgba(0,212,255,0.25)',
-                        color: exportComboIndex === index ? 'rgba(0,212,255,0.4)' : 'var(--color-accent)',
-                        opacity: (exportComboIndex !== null || isDownloading) && exportComboIndex !== index ? 0.4 : 1,
-                        cursor: (exportComboIndex !== null || isDownloading) ? 'not-allowed' : 'pointer',
-                      }}
-                    >
-                      <IconDownload />
-                    </button>
+                    <div style={{ position: 'relative', display: 'inline-flex' }} onClick={(e) => e.stopPropagation()}>
+                      <button
+                        onClick={() => handleDownloadCombo(index)}
+                        disabled={exportComboIndex !== null || isDownloading}
+                        title="Download this combo"
+                        aria-label={`Download combo ${index + 1}`}
+                        className="flex items-center justify-center w-7 h-7 transition-all hover:brightness-110"
+                        style={{
+                          background: 'var(--color-accent-dim)',
+                          border: '1px solid rgba(0,212,255,0.25)',
+                          borderRight: 'none',
+                          borderRadius: '6px 0 0 6px',
+                          color: exportComboIndex === index ? 'rgba(0,212,255,0.4)' : 'var(--color-accent)',
+                          opacity: (exportComboIndex !== null || isDownloading) && exportComboIndex !== index ? 0.4 : 1,
+                          cursor: (exportComboIndex !== null || isDownloading) ? 'not-allowed' : 'pointer',
+                        }}
+                      >
+                        <IconDownload />
+                      </button>
+                      <button
+                        onClick={() => setShowComboStyleMenu((v) => v === index ? null : index)}
+                        disabled={exportComboIndex !== null || isDownloading}
+                        style={{
+                          display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          padding: '0 4px', height: '28px',
+                          background: 'var(--color-accent-dim)',
+                          border: '1px solid rgba(0,212,255,0.25)',
+                          borderLeft: '1px solid rgba(0,212,255,0.15)',
+                          borderRadius: '0 6px 6px 0',
+                          color: 'var(--color-accent)',
+                          cursor: (exportComboIndex !== null || isDownloading) ? 'not-allowed' : 'pointer',
+                          opacity: (exportComboIndex !== null || isDownloading) ? 0.4 : 1,
+                        }}
+                        aria-label="Choose combo export style"
+                      >
+                        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                          <path d={showComboStyleMenu === index ? 'M6 15l6-6 6 6' : 'M6 9l6 6 6-6'} />
+                        </svg>
+                      </button>
+                      {showComboStyleMenu === index && (
+                        <div style={{
+                          position: 'absolute', top: 'calc(100% + 4px)', right: 0,
+                          background: 'var(--color-surface)', border: '1px solid var(--color-border)',
+                          borderRadius: '8px', minWidth: '180px', overflow: 'hidden',
+                          boxShadow: '0 8px 32px rgba(0,0,0,0.6)', zIndex: 20,
+                        }}>
+                          {[
+                            { id: 'single',        label: 'Single Combo',       desc: 'Large image, full bars' },
+                            { id: 'compact-image', label: 'Compact with Image', desc: 'Small image + bars' },
+                          ].map(({ id, label, desc }) => (
+                            <button key={id}
+                              onClick={() => { setShowComboStyleMenu(null); handleDownloadCombo(index, id); }}
+                              style={{
+                                display: 'flex', alignItems: 'center', gap: '10px',
+                                width: '100%', padding: '9px 14px', textAlign: 'left',
+                                background: comboExportStyle === id ? 'var(--color-accent-dim)' : 'transparent',
+                                borderLeft: comboExportStyle === id ? '2px solid var(--color-accent)' : '2px solid transparent',
+                                border: 'none', cursor: 'pointer',
+                              }}
+                            >
+                              <div>
+                                <div style={{ fontSize: '12px', color: comboExportStyle === id ? 'var(--color-accent)' : 'var(--color-text)', fontWeight: 700, fontFamily: 'var(--font-heading)' }}>{label}</div>
+                                <div style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>{desc}</div>
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
 
@@ -489,7 +558,7 @@ function App() {
           </button>
 
           <button
-            onClick={handleShareButton}
+            onClick={() => setShowShareModal(true)}
             className="flex items-center gap-2 px-6 py-2.5 rounded-lg text-sm font-bold uppercase tracking-wider transition-all hover:brightness-110"
             style={{
               background: 'var(--color-accent-dim)',
@@ -503,25 +572,80 @@ function App() {
           </button>
 
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px' }}>
-            <button
-              onClick={handleDownloadDeck}
-              disabled={isDownloading}
-              className="flex items-center gap-2 px-6 py-2.5 rounded-lg text-sm font-bold uppercase tracking-wider transition-all hover:brightness-110"
-              style={{
-                background: 'var(--color-accent-dim)',
-                border: '1px solid rgba(0,212,255,0.4)',
-                color: 'var(--color-accent)',
-                fontFamily: 'var(--font-heading)',
-                opacity: isDownloading ? 0.6 : 1,
-                cursor: isDownloading ? 'not-allowed' : 'pointer',
-              }}
-            >
-              <IconDownload />
-              {isDownloading ? 'Generating…' : 'Download Deck'}
-            </button>
-            {downloadError && (
-              <span className="text-xs" style={{ color: '#ff4455' }}>{downloadError}</span>
-            )}
+            <div style={{ position: 'relative', display: 'inline-flex', borderRadius: '8px', overflow: 'visible' }} onClick={(e) => e.stopPropagation()}>
+              <button
+                onClick={() => handleDownloadDeck()}
+                disabled={isDownloading}
+                className="flex items-center gap-2 px-6 py-2.5 text-sm font-bold uppercase tracking-wider transition-all hover:brightness-110"
+                style={{
+                  background: 'var(--color-accent-dim)',
+                  border: '1px solid rgba(0,212,255,0.4)',
+                  borderRight: 'none',
+                  borderRadius: '8px 0 0 8px',
+                  color: 'var(--color-accent)',
+                  fontFamily: 'var(--font-heading)',
+                  opacity: isDownloading ? 0.6 : 1,
+                  cursor: isDownloading ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <IconDownload />
+                {isDownloading ? 'Generating…' : 'Download Deck'}
+              </button>
+              <button
+                onClick={() => setShowDeckStyleMenu((v) => !v)}
+                disabled={isDownloading}
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  padding: '0 10px',
+                  background: 'var(--color-accent-dim)',
+                  border: '1px solid rgba(0,212,255,0.4)',
+                  borderLeft: '1px solid rgba(0,212,255,0.2)',
+                  borderRadius: '0 8px 8px 0',
+                  color: 'var(--color-accent)',
+                  cursor: isDownloading ? 'not-allowed' : 'pointer',
+                  opacity: isDownloading ? 0.6 : 1,
+                }}
+                aria-label="Choose download style"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d={showDeckStyleMenu ? 'M6 15l6-6 6 6' : 'M6 9l6 6 6-6'} />
+                </svg>
+              </button>
+              {showDeckStyleMenu && (
+                <div style={{
+                  position: 'absolute', top: 'calc(100% + 4px)', left: 0,
+                  background: 'var(--color-surface)', border: '1px solid var(--color-border)',
+                  borderRadius: '8px', minWidth: '200px', overflow: 'hidden',
+                  boxShadow: '0 8px 32px rgba(0,0,0,0.6)', zIndex: 20,
+                }}>
+                  {[
+                    { id: 'deck',          label: 'Deck Card',         desc: 'All combos, images, bars' },
+                    { id: 'compact',       label: 'Compact List',       desc: 'Names only' },
+                    { id: 'compact-image', label: 'Compact with Image', desc: 'Small image + bars' },
+                  ].map(({ id, label, desc }) => (
+                    <button key={id}
+                      onClick={() => { setDeckExportStyle(id); setShowDeckStyleMenu(false); }}
+                      style={{
+                        display: 'flex', alignItems: 'center', gap: '10px',
+                        width: '100%', padding: '9px 14px', textAlign: 'left',
+                        background: deckExportStyle === id ? 'var(--color-accent-dim)' : 'transparent',
+                        borderLeft: deckExportStyle === id ? '2px solid var(--color-accent)' : '2px solid transparent',
+                        border: 'none', cursor: 'pointer',
+                      }}
+                    >
+                      <div>
+                        <div style={{ fontSize: '12px', color: deckExportStyle === id ? 'var(--color-accent)' : 'var(--color-text)', fontWeight: 700, fontFamily: 'var(--font-heading)' }}>{label}</div>
+                        <div style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>{desc}</div>
+                      </div>
+                      {deckExportStyle === id && (
+                        <svg style={{ marginLeft: 'auto', flexShrink: 0 }} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M20 6L9 17l-5-5" /></svg>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {downloadError && <span className="text-xs" style={{ color: '#ff4455' }}>{downloadError}</span>}
           </div>
         </div>
 
@@ -566,18 +690,33 @@ function App() {
 
       {/* Off-screen export target */}
       <div style={{ position: 'fixed', left: '-9999px', top: 0, pointerEvents: 'none' }}>
-        <ExportCard
-          ref={exportRef}
-          beyblades={beyblades}
-          beybladeCount={beybladeCount}
-          format={currentFormat}
-          comboIndex={exportComboIndex}
-        />
+        <div ref={exportRef} style={{ width: exportComboIndex !== null ? '320px' : '480px' }}>
+          {exportComboIndex !== null ? (
+            comboExportStyle === 'single'
+              ? <SingleComboWidget combo={beyblades[exportComboIndex]} />
+              : <CompactImageWidget combos={[beyblades[exportComboIndex]]} beybladeCount={1} format={currentFormat} />
+          ) : (
+            deckExportStyle === 'compact'
+              ? <CompactListWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+              : deckExportStyle === 'compact-image'
+                ? <CompactImageWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+                : <DeckWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+          )}
+        </div>
       </div>
 
       {/* ── Support Popup (auto-shown) ── */}
       {showSupportPopup && (
         <SupportPopup onClose={() => setShowSupportPopup(false)} />
+      )}
+
+      {showShareModal && (
+        <ShareModal
+          beyblades={beyblades}
+          beybladeCount={beybladeCount}
+          currentFormat={currentFormat}
+          onClose={() => setShowShareModal(false)}
+        />
       )}
 
     </div>

--- a/src/EmbedApp.jsx
+++ b/src/EmbedApp.jsx
@@ -1,0 +1,29 @@
+import DeckWidget from './components/widgets/DeckWidget';
+import SingleComboWidget from './components/widgets/SingleComboWidget';
+import CompactListWidget from './components/widgets/CompactListWidget';
+import CompactImageWidget from './components/widgets/CompactImageWidget';
+import { parseSharedBeys } from './lib/comboUtils';
+
+function EmbedApp() {
+  const params = new URLSearchParams(window.location.search);
+  const widgetType = params.get('widget');
+  const format = params.get('format') || 'standard';
+  const beynum = Math.max(1, Number(params.get('beynum')) || 1);
+  const rawBeys = params.getAll('beys');
+  const combos = parseSharedBeys(rawBeys);
+
+  const style = { margin: 0, padding: 0, background: 'transparent' };
+
+  if (widgetType === 'single') {
+    return <div style={style}><SingleComboWidget combo={combos[0]} /></div>;
+  }
+  if (widgetType === 'compact') {
+    return <div style={style}><CompactListWidget combos={combos} beybladeCount={beynum} format={format} /></div>;
+  }
+  if (widgetType === 'compact-image') {
+    return <div style={style}><CompactImageWidget combos={combos} beybladeCount={beynum} format={format} /></div>;
+  }
+  return <div style={style}><DeckWidget combos={combos} beybladeCount={beynum} format={format} /></div>;
+}
+
+export default EmbedApp;

--- a/src/components/ExportCard.jsx
+++ b/src/components/ExportCard.jsx
@@ -1,48 +1,14 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { BEYBLADE_DB, LIMITED_FORMAT, getStats } from '../constants';
+import { BEYBLADE_DB, LIMITED_FORMAT } from '../constants';
+import { STAT_DEFS, getComboStats, getComboName } from '../lib/comboUtils';
 
 const ACCENT_COLORS = ['#00d4ff', '#7b61ff', '#ffa040'];
-
-const STAT_DEFS = [
-  { key: 'attack',          label: 'ATTACK',  gradient: 'linear-gradient(90deg,#1565c0,#00d4ff)', color: '#00d4ff', limit: 2 },
-  { key: 'defense',         label: 'DEFENSE', gradient: 'linear-gradient(90deg,#2e7d32,#00e676)', color: '#00e676', limit: 2 },
-  { key: 'stamina',         label: 'STAMINA', gradient: 'linear-gradient(90deg,#e65100,#ffcc02)', color: '#ffcc02', limit: 2 },
-  { key: 'xDash',           label: 'X-DASH',  gradient: 'linear-gradient(90deg,#b71c1c,#ff6d00)', color: '#ff6d00', limit: 1 },
-  { key: 'burstResistance', label: 'BURST',   gradient: 'linear-gradient(90deg,#4a148c,#aa00ff)', color: '#aa00ff', limit: 1 },
-];
 
 const DOT_BG = {
   backgroundImage: 'radial-gradient(rgba(0,212,255,0.06) 1px, transparent 1px)',
   backgroundSize: '20px 20px',
 };
-
-function getComboStats(combo) {
-  const { blade, assistBlade, ratchet, bit, bladeMode = 0, assistBladeMode = 0, bitMode = 0 } = combo || {};
-  const bladeStats   = getStats(blade, bladeMode);
-  const assistStats  = getStats(assistBlade, assistBladeMode);
-  const ratchetStats = getStats(ratchet);
-  const bitStats     = getStats(bit, bitMode);
-  return {
-    attack:          (bladeStats.attack          || 0) + (assistStats.attack          || 0) + (ratchetStats.attack          || 0) + (bitStats.attack          || 0),
-    defense:         (bladeStats.defense         || 0) + (assistStats.defense         || 0) + (ratchetStats.defense         || 0) + (bitStats.defense         || 0),
-    stamina:         (bladeStats.stamina         || 0) + (assistStats.stamina         || 0) + (ratchetStats.stamina         || 0) + (bitStats.stamina         || 0),
-    xDash:           bitStats.xDash           || 0,
-    burstResistance: bitStats.burstResistance || 0,
-  };
-}
-
-function getComboName(combo) {
-  const { blade, assistBlade, ratchet, bit, lockChip } = combo || {};
-  const isCXLine = BEYBLADE_DB[blade]?.line === 'CX';
-  return [
-    isCXLine && lockChip ? lockChip : null,
-    blade,
-    isCXLine ? BEYBLADE_DB[assistBlade]?.alias : null,
-    BEYBLADE_DB[ratchet]?.altname,
-    BEYBLADE_DB[bit]?.alias,
-  ].filter(Boolean).join(' ');
-}
 
 const MODE_STAT_KEYS = ['attack', 'defense', 'stamina'];
 const MODE_STAT_COLORS = { attack: '#00d4ff', defense: '#00e676', stamina: '#ffcc02' };

--- a/src/components/ShareModal.jsx
+++ b/src/components/ShareModal.jsx
@@ -1,0 +1,171 @@
+import { useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { buildShareUrl, buildEmbedUrl } from '../lib/shareUrl';
+
+const WIDGET_OPTIONS = [
+  { id: 'deck',          label: 'Deck Card',          desc: 'All combos, images, stat bars' },
+  { id: 'single',        label: 'Single Combo',        desc: 'One combo, large image' },
+  { id: 'compact',       label: 'Compact List',         desc: 'Names only, minimal' },
+  { id: 'compact-image', label: 'Compact with Image',   desc: 'Small image + condensed bars' },
+];
+
+const surfaceStyle = {
+  background: 'var(--color-surface)',
+  border: '1px solid var(--color-border)',
+  borderRadius: '16px',
+  boxShadow: '0 8px 40px rgba(0,0,0,0.7)',
+};
+
+function CopyButton({ text, label = 'Copy' }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [text]);
+  return (
+    <button
+      onClick={handleCopy}
+      style={{
+        padding: '6px 14px', borderRadius: '6px', fontSize: '11px', fontWeight: 700,
+        cursor: 'pointer', fontFamily: 'var(--font-heading)', letterSpacing: '0.08em',
+        background: copied ? 'rgba(0,230,118,0.15)' : 'var(--color-accent-dim)',
+        border: copied ? '1px solid rgba(0,230,118,0.4)' : '1px solid rgba(0,212,255,0.4)',
+        color: copied ? '#00e676' : 'var(--color-accent)',
+        transition: 'all 0.2s',
+      }}
+    >
+      {copied ? 'Copied!' : label}
+    </button>
+  );
+}
+CopyButton.propTypes = { text: PropTypes.string.isRequired, label: PropTypes.string };
+
+function ShareModal({ beyblades, beybladeCount, currentFormat, onClose }) {
+  const [activeTab, setActiveTab] = useState('share');
+  const [widgetType, setWidgetType] = useState('deck');
+  const [comboIndex, setComboIndex] = useState(0);
+
+  const shareUrl = buildShareUrl(beyblades, beybladeCount, currentFormat);
+  const embedUrl = buildEmbedUrl(beyblades, beybladeCount, currentFormat, widgetType, comboIndex);
+  const iframeSnippet = `<iframe\n  src="${embedUrl}"\n  width="500" height="300"\n  frameborder="0" style="border:none">\n</iframe>`;
+
+  const tabStyle = (tab) => ({
+    flex: 1, padding: '10px', fontSize: '12px', fontWeight: 700,
+    letterSpacing: '0.08em', fontFamily: 'var(--font-heading)',
+    cursor: 'pointer', border: 'none', borderRadius: '8px',
+    background: activeTab === tab ? 'var(--color-accent-dim)' : 'transparent',
+    color: activeTab === tab ? 'var(--color-accent)' : 'var(--color-text-muted)',
+    transition: 'all 0.15s',
+  });
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '16px' }}
+      onClick={onClose}
+    >
+      <div style={{ ...surfaceStyle, width: '100%', maxWidth: '520px', padding: '24px' }} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
+          <span style={{ fontFamily: 'var(--font-heading)', fontSize: '14px', fontWeight: 900, letterSpacing: '0.08em', color: 'var(--color-accent)' }}>SHARE DECK</span>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-muted)', fontSize: '18px', lineHeight: 1 }}>×</button>
+        </div>
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', gap: '4px', background: 'var(--color-surface-2)', borderRadius: '10px', padding: '4px', marginBottom: '20px' }}>
+          <button style={tabStyle('share')} onClick={() => setActiveTab('share')}>SHARE LINK</button>
+          <button style={tabStyle('embed')} onClick={() => setActiveTab('embed')}>EMBED</button>
+        </div>
+
+        {activeTab === 'share' && (
+          <div>
+            <p style={{ fontSize: '12px', color: 'var(--color-text-muted)', marginBottom: '12px' }}>Share this link to let others view your deck.</p>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+              <input
+                readOnly value={shareUrl}
+                style={{ flex: 1, padding: '8px 10px', borderRadius: '8px', fontSize: '11px', background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', color: 'var(--color-text-muted)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              />
+              <CopyButton text={shareUrl} />
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'embed' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            {/* Widget type picker */}
+            <div>
+              <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', letterSpacing: '0.12em', marginBottom: '8px', fontWeight: 700 }}>WIDGET STYLE</div>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px' }}>
+                {WIDGET_OPTIONS.map(({ id, label, desc }) => {
+                  const active = widgetType === id;
+                  return (
+                    <button key={id} onClick={() => setWidgetType(id)}
+                      style={{
+                        padding: '10px 12px', borderRadius: '8px', textAlign: 'left', cursor: 'pointer',
+                        background: active ? 'var(--color-accent-dim)' : 'var(--color-surface-2)',
+                        border: active ? '1px solid rgba(0,212,255,0.4)' : '1px solid var(--color-border)',
+                      }}
+                    >
+                      <div style={{ fontSize: '12px', fontWeight: 700, color: active ? 'var(--color-accent)' : 'var(--color-text)' }}>{label}</div>
+                      <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', marginTop: '2px' }}>{desc}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Combo picker (single only) */}
+            {widgetType === 'single' && (
+              <div>
+                <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', letterSpacing: '0.12em', marginBottom: '6px', fontWeight: 700 }}>COMBO</div>
+                <select
+                  value={comboIndex}
+                  onChange={(e) => setComboIndex(Number(e.target.value))}
+                  style={{ padding: '7px 10px', borderRadius: '8px', background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', color: 'var(--color-text)', fontSize: '12px', cursor: 'pointer' }}
+                >
+                  {Array(beybladeCount).fill(null).map((_, i) => (
+                    <option key={i} value={i}>Combo {i + 1}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Live preview */}
+            <div>
+              <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', letterSpacing: '0.12em', marginBottom: '6px', fontWeight: 700 }}>PREVIEW</div>
+              <div style={{ borderRadius: '8px', overflow: 'hidden', border: '1px solid var(--color-border)', background: '#080c18' }}>
+                <iframe
+                  key={embedUrl}
+                  src={embedUrl}
+                  style={{ width: '100%', height: '280px', border: 'none', display: 'block' }}
+                  title="Widget preview"
+                />
+              </div>
+            </div>
+
+            {/* Code snippet */}
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '6px' }}>
+                <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', letterSpacing: '0.12em', fontWeight: 700 }}>EMBED CODE</div>
+                <CopyButton text={iframeSnippet} label="Copy Code" />
+              </div>
+              <pre style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', borderRadius: '8px', padding: '10px 12px', fontSize: '10px', color: 'var(--color-text-muted)', fontFamily: 'monospace', overflowX: 'auto', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {iframeSnippet}
+              </pre>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+ShareModal.propTypes = {
+  beyblades: PropTypes.array.isRequired,
+  beybladeCount: PropTypes.number.isRequired,
+  currentFormat: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default ShareModal;

--- a/src/components/ShareModal.jsx
+++ b/src/components/ShareModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { buildShareUrl, buildEmbedUrl } from '../lib/shareUrl';
 
@@ -18,12 +18,14 @@ const surfaceStyle = {
 
 function CopyButton({ text, label = 'Copy' }) {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef(null);
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
     });
   }, [text]);
+  useEffect(() => () => clearTimeout(timerRef.current), []);
   return (
     <button
       onClick={handleCopy}
@@ -46,6 +48,10 @@ function ShareModal({ beyblades, beybladeCount, currentFormat, onClose }) {
   const [activeTab, setActiveTab] = useState('share');
   const [widgetType, setWidgetType] = useState('deck');
   const [comboIndex, setComboIndex] = useState(0);
+
+  useEffect(() => {
+    if (comboIndex >= beybladeCount) setComboIndex(Math.max(0, beybladeCount - 1));
+  }, [beybladeCount, comboIndex]);
 
   const shareUrl = buildShareUrl(beyblades, beybladeCount, currentFormat);
   const embedUrl = buildEmbedUrl(beyblades, beybladeCount, currentFormat, widgetType, comboIndex);

--- a/src/components/ShareModal.jsx
+++ b/src/components/ShareModal.jsx
@@ -9,6 +9,15 @@ const WIDGET_OPTIONS = [
   { id: 'compact-image', label: 'Compact with Image',   desc: 'Small image + condensed bars' },
 ];
 
+function calcEmbedHeight(widgetType, beybladeCount) {
+  switch (widgetType) {
+    case 'single': return 220;
+    case 'compact': return 75 + beybladeCount * 32;
+    case 'compact-image': return 75 + beybladeCount * 36;
+    default: return 130 + beybladeCount * 72; // deck
+  }
+}
+
 const surfaceStyle = {
   background: 'var(--color-surface)',
   border: '1px solid var(--color-border)',
@@ -55,7 +64,8 @@ function ShareModal({ beyblades, beybladeCount, currentFormat, onClose }) {
 
   const shareUrl = buildShareUrl(beyblades, beybladeCount, currentFormat);
   const embedUrl = buildEmbedUrl(beyblades, beybladeCount, currentFormat, widgetType, comboIndex);
-  const iframeSnippet = `<iframe\n  src="${embedUrl}"\n  width="500" height="300"\n  frameborder="0" style="border:none">\n</iframe>`;
+  const embedHeight = calcEmbedHeight(widgetType, widgetType === 'single' ? 1 : beybladeCount);
+  const iframeSnippet = `<iframe\n  src="${embedUrl}"\n  width="100%" height="${embedHeight}"\n  frameborder="0" style="border:none">\n</iframe>`;
 
   const tabStyle = (tab) => ({
     flex: 1, padding: '10px', fontSize: '12px', fontWeight: 700,
@@ -144,7 +154,7 @@ function ShareModal({ beyblades, beybladeCount, currentFormat, onClose }) {
                 <iframe
                   key={embedUrl}
                   src={embedUrl}
-                  style={{ width: '100%', height: '280px', border: 'none', display: 'block' }}
+                  style={{ width: '100%', height: `${embedHeight}px`, border: 'none', display: 'block' }}
                   title="Widget preview"
                 />
               </div>

--- a/src/components/widgets/CompactImageWidget.jsx
+++ b/src/components/widgets/CompactImageWidget.jsx
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import { BEYBLADE_DB, LIMITED_FORMAT } from '../../constants';
+import { getComboStats, getComboName, STAT_DEFS } from '../../lib/comboUtils';
+
+const ACCENT_COLORS = ['#00d4ff', '#7b61ff', '#ffa040'];
+const MAIN_STATS = STAT_DEFS.slice(0, 3); // attack, defense, stamina
+
+function CompactComboRow({ combo, accent }) {
+  const { blade, lockChip } = combo || {};
+  const isCXLine = BEYBLADE_DB[blade]?.line === 'CX';
+  const stats = getComboStats(combo);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <div style={{ position: 'relative', width: '26px', height: '26px', flexShrink: 0 }}>
+        {blade && BEYBLADE_DB[blade]?.image && (
+          <img src={`/images/${BEYBLADE_DB[blade].image}`} alt={blade}
+            style={{ width: '26px', height: '26px', borderRadius: '50%', objectFit: 'contain', background: '#0f1e2e', border: `1px solid ${accent}66` }}
+          />
+        )}
+        {isCXLine && lockChip && BEYBLADE_DB[lockChip]?.image && (
+          <img src={`/images/${BEYBLADE_DB[lockChip].image}`} alt={lockChip}
+            style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', width: '38%', height: '38%', objectFit: 'contain' }}
+          />
+        )}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: '9px', color: '#fff', fontWeight: 800, marginBottom: '3px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {getComboName(combo) || '—'}
+        </div>
+        <div style={{ display: 'flex', gap: '2px', height: '2px' }}>
+          {MAIN_STATS.map(({ key, gradient, limit }) => {
+            const val = stats[key] || 0;
+            const flex = Math.max(1, Math.round((val / limit) * 100));
+            return <div key={key} style={{ flex, background: gradient, borderRadius: '1px' }} />;
+          })}
+          <div style={{ flex: 100 - MAIN_STATS.reduce((sum, { key, limit }) => sum + Math.round(((stats[key] || 0) / limit) * 100), 0), background: 'rgba(255,255,255,0.07)', borderRadius: '1px' }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompactImageWidget({ combos, beybladeCount, format }) {
+  const formatLabel = format === LIMITED_FORMAT ? 'LIMITED' : 'STANDARD';
+  return (
+    <div style={{ background: '#080c18', borderRadius: '12px', padding: '14px 16px', fontFamily: 'system-ui,-apple-system,sans-serif', border: '1px solid rgba(255,255,255,0.06)' }}>
+      <div style={{ fontSize: '6.5px', color: 'rgba(0,212,255,0.6)', letterSpacing: '0.22em', fontWeight: 700, marginBottom: '10px' }}>BEYBREW · {formatLabel}</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        {Array(beybladeCount).fill(null).map((_, i) => (
+          <CompactComboRow key={i} combo={combos[i]} accent={ACCENT_COLORS[i % ACCENT_COLORS.length]} />
+        ))}
+      </div>
+      <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,transparent,rgba(255,255,255,0.08))' }} />
+        <span style={{ fontSize: '6.5px', color: 'rgba(255,255,255,0.2)', letterSpacing: '0.18em', fontWeight: 600 }}>BEYBLADEBREW.COM</span>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,rgba(255,255,255,0.08),transparent)' }} />
+      </div>
+    </div>
+  );
+}
+
+CompactImageWidget.propTypes = {
+  combos: PropTypes.array.isRequired,
+  beybladeCount: PropTypes.number.isRequired,
+  format: PropTypes.string,
+};
+
+export default CompactImageWidget;

--- a/src/components/widgets/CompactImageWidget.jsx
+++ b/src/components/widgets/CompactImageWidget.jsx
@@ -33,12 +33,13 @@ function CompactComboRow({ combo, accent }) {
             const flex = Math.max(1, Math.round((val / limit) * 100));
             return <div key={key} style={{ flex, background: gradient, borderRadius: '1px' }} />;
           })}
-          <div style={{ flex: 100 - MAIN_STATS.reduce((sum, { key, limit }) => sum + Math.round(((stats[key] || 0) / limit) * 100), 0), background: 'rgba(255,255,255,0.07)', borderRadius: '1px' }} />
+          <div style={{ flex: Math.max(0, 100 - MAIN_STATS.reduce((sum, { key, limit }) => sum + Math.round(((stats[key] || 0) / limit) * 100), 0)), background: 'rgba(255,255,255,0.07)', borderRadius: '1px' }} />
         </div>
       </div>
     </div>
   );
 }
+CompactComboRow.propTypes = { combo: PropTypes.object, accent: PropTypes.string.isRequired };
 
 function CompactImageWidget({ combos, beybladeCount, format }) {
   const formatLabel = format === LIMITED_FORMAT ? 'LIMITED' : 'STANDARD';

--- a/src/components/widgets/CompactImageWidget.jsx
+++ b/src/components/widgets/CompactImageWidget.jsx
@@ -30,10 +30,10 @@ function CompactComboRow({ combo, accent }) {
         <div style={{ display: 'flex', gap: '2px', height: '2px' }}>
           {MAIN_STATS.map(({ key, gradient, limit }) => {
             const val = stats[key] || 0;
-            const flex = Math.max(1, Math.round((val / limit) * 100));
+            const flex = Math.max(1, Math.round(val / limit));
             return <div key={key} style={{ flex, background: gradient, borderRadius: '1px' }} />;
           })}
-          <div style={{ flex: Math.max(0, 100 - MAIN_STATS.reduce((sum, { key, limit }) => sum + Math.round(((stats[key] || 0) / limit) * 100), 0)), background: 'rgba(255,255,255,0.07)', borderRadius: '1px' }} />
+          <div style={{ flex: Math.max(0, 100 - MAIN_STATS.reduce((sum, { key, limit }) => sum + Math.round((stats[key] || 0) / limit), 0)), background: 'rgba(255,255,255,0.07)', borderRadius: '1px' }} />
         </div>
       </div>
     </div>

--- a/src/components/widgets/CompactListWidget.jsx
+++ b/src/components/widgets/CompactListWidget.jsx
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import { LIMITED_FORMAT } from '../../constants';
+import { getComboName } from '../../lib/comboUtils';
+
+const ACCENT_COLORS = ['#00d4ff', '#7b61ff', '#ffa040'];
+
+function CompactListWidget({ combos, beybladeCount, format }) {
+  const formatLabel = format === LIMITED_FORMAT ? 'LIMITED' : 'STANDARD';
+  return (
+    <div style={{ background: '#080c18', borderRadius: '12px', padding: '14px 16px', fontFamily: 'system-ui,-apple-system,sans-serif', border: '1px solid rgba(255,255,255,0.06)' }}>
+      <div style={{ fontSize: '6.5px', color: 'rgba(0,212,255,0.6)', letterSpacing: '0.22em', fontWeight: 700, marginBottom: '10px' }}>BEYBREW · {formatLabel}</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+        {Array(beybladeCount).fill(null).map((_, i) => {
+          const name = getComboName(combos[i]);
+          const accent = ACCENT_COLORS[i % ACCENT_COLORS.length];
+          return (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <span style={{ fontSize: '9px', color: accent, width: '14px', fontWeight: 700, flexShrink: 0 }}>{i + 1}</span>
+              <span style={{ fontSize: '11px', color: '#fff', fontWeight: 700 }}>{name || '—'}</span>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,transparent,rgba(255,255,255,0.08))' }} />
+        <span style={{ fontSize: '6.5px', color: 'rgba(255,255,255,0.2)', letterSpacing: '0.18em', fontWeight: 600 }}>BEYBLADEBREW.COM</span>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,rgba(255,255,255,0.08),transparent)' }} />
+      </div>
+    </div>
+  );
+}
+
+CompactListWidget.propTypes = {
+  combos: PropTypes.array.isRequired,
+  beybladeCount: PropTypes.number.isRequired,
+  format: PropTypes.string,
+};
+
+export default CompactListWidget;

--- a/src/components/widgets/DeckWidget.jsx
+++ b/src/components/widgets/DeckWidget.jsx
@@ -1,0 +1,87 @@
+import PropTypes from 'prop-types';
+import { BEYBLADE_DB, LIMITED_FORMAT } from '../../constants';
+import { getComboStats, getComboName, STAT_DEFS } from '../../lib/comboUtils';
+
+const ACCENT_COLORS = ['#00d4ff', '#7b61ff', '#ffa040'];
+const DOT_BG = {
+  backgroundImage: 'radial-gradient(rgba(0,212,255,0.06) 1px, transparent 1px)',
+  backgroundSize: '20px 20px',
+};
+
+function StatBars({ stats }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+      {STAT_DEFS.map(({ key, label, gradient, color, limit }) => {
+        const value = stats[key] || 0;
+        const pct = Math.min(100, (value / limit) * 100);
+        return (
+          <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <span style={{ fontSize: '6.5px', color: 'rgba(255,255,255,0.35)', letterSpacing: '0.12em', width: '48px', flexShrink: 0 }}>{label}</span>
+            <div style={{ flex: 1, height: '3px', borderRadius: '2px', background: 'rgba(255,255,255,0.07)', overflow: 'hidden' }}>
+              <div style={{ height: '100%', width: `${pct}%`, background: gradient, borderRadius: '2px' }} />
+            </div>
+            <span style={{ fontSize: '6.5px', color, fontWeight: 700, width: '20px', textAlign: 'right' }}>{value}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ComboRow({ combo, accent }) {
+  const { blade, lockChip } = combo || {};
+  const isCXLine = BEYBLADE_DB[blade]?.line === 'CX';
+  return (
+    <div style={{ background: 'rgba(255,255,255,0.03)', border: `1px solid ${accent}33`, borderLeft: `3px solid ${accent}`, borderRadius: '10px', padding: '10px 12px', display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <div style={{ position: 'relative', width: '44px', height: '44px', flexShrink: 0 }}>
+        {blade && BEYBLADE_DB[blade]?.image && (
+          <img src={`/images/${BEYBLADE_DB[blade].image}`} alt={blade}
+            style={{ width: '44px', height: '44px', borderRadius: '50%', objectFit: 'contain', background: '#0f1e2e', border: `2px solid ${accent}80` }}
+          />
+        )}
+        {isCXLine && lockChip && BEYBLADE_DB[lockChip]?.image && (
+          <img src={`/images/${BEYBLADE_DB[lockChip].image}`} alt={lockChip}
+            style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', width: '38%', height: '38%', objectFit: 'contain' }}
+          />
+        )}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: '10px', fontWeight: 800, color: '#fff', marginBottom: '5px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {getComboName(combo) || '—'}
+        </div>
+        <StatBars stats={getComboStats(combo)} />
+      </div>
+    </div>
+  );
+}
+
+function DeckWidget({ combos, beybladeCount, format }) {
+  const formatLabel = format === LIMITED_FORMAT ? 'LIMITED' : 'STANDARD';
+  return (
+    <div style={{ ...DOT_BG, background: '#080c18', borderRadius: '12px', padding: '20px', fontFamily: 'system-ui,-apple-system,sans-serif', overflow: 'hidden' }}>
+      <div style={{ textAlign: 'center', marginBottom: '16px' }}>
+        <div style={{ fontSize: '22px', fontWeight: 900, letterSpacing: '0.08em', background: 'linear-gradient(90deg,#00d4ff,#7b61ff)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', backgroundClip: 'text' }}>BEYBREW</div>
+        <div style={{ width: '60px', height: '1px', background: 'linear-gradient(90deg,transparent,#00d4ff,transparent)', margin: '4px auto' }} />
+        <div style={{ fontSize: '7px', color: 'rgba(0,212,255,0.7)', letterSpacing: '0.22em', fontWeight: 600 }}>BEYBLADE X DECK · {formatLabel}</div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        {Array(beybladeCount).fill(null).map((_, i) => (
+          <ComboRow key={i} combo={combos[i]} accent={ACCENT_COLORS[i % ACCENT_COLORS.length]} />
+        ))}
+      </div>
+      <div style={{ marginTop: '14px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,transparent,rgba(255,255,255,0.08))' }} />
+        <span style={{ fontSize: '7px', color: 'rgba(255,255,255,0.2)', letterSpacing: '0.18em', fontWeight: 600 }}>BEYBLADEBREW.COM</span>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,rgba(255,255,255,0.08),transparent)' }} />
+      </div>
+    </div>
+  );
+}
+
+DeckWidget.propTypes = {
+  combos: PropTypes.array.isRequired,
+  beybladeCount: PropTypes.number.isRequired,
+  format: PropTypes.string,
+};
+
+export default DeckWidget;

--- a/src/components/widgets/DeckWidget.jsx
+++ b/src/components/widgets/DeckWidget.jsx
@@ -13,7 +13,7 @@ function StatBars({ stats }) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
       {STAT_DEFS.map(({ key, label, gradient, color, limit }) => {
         const value = stats[key] || 0;
-        const pct = Math.min(100, (value / limit) * 100);
+        const pct = Math.min(100, value / limit);
         return (
           <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <span style={{ fontSize: '6.5px', color: 'rgba(255,255,255,0.35)', letterSpacing: '0.12em', width: '48px', flexShrink: 0 }}>{label}</span>

--- a/src/components/widgets/DeckWidget.jsx
+++ b/src/components/widgets/DeckWidget.jsx
@@ -27,6 +27,7 @@ function StatBars({ stats }) {
     </div>
   );
 }
+StatBars.propTypes = { stats: PropTypes.object.isRequired };
 
 function ComboRow({ combo, accent }) {
   const { blade, lockChip } = combo || {};
@@ -54,6 +55,7 @@ function ComboRow({ combo, accent }) {
     </div>
   );
 }
+ComboRow.propTypes = { combo: PropTypes.object, accent: PropTypes.string.isRequired };
 
 function DeckWidget({ combos, beybladeCount, format }) {
   const formatLabel = format === LIMITED_FORMAT ? 'LIMITED' : 'STANDARD';

--- a/src/components/widgets/SingleComboWidget.jsx
+++ b/src/components/widgets/SingleComboWidget.jsx
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import { BEYBLADE_DB } from '../../constants';
+import { getComboStats, getComboName, STAT_DEFS } from '../../lib/comboUtils';
+
+const DOT_BG = {
+  backgroundImage: 'radial-gradient(rgba(0,212,255,0.06) 1px, transparent 1px)',
+  backgroundSize: '20px 20px',
+};
+const ACCENT = '#00d4ff';
+
+function SingleComboWidget({ combo }) {
+  const { blade, lockChip } = combo || {};
+  const isCXLine = BEYBLADE_DB[blade]?.line === 'CX';
+  const stats = getComboStats(combo);
+  const name = getComboName(combo);
+  const spinType = BEYBLADE_DB[blade]?.spinType;
+  const bitType = BEYBLADE_DB[combo?.bit]?.type;
+
+  return (
+    <div style={{ ...DOT_BG, background: '#080c18', borderRadius: '14px', border: `1px solid ${ACCENT}33`, borderLeft: `3px solid ${ACCENT}`, padding: '18px', fontFamily: 'system-ui,-apple-system,sans-serif' }}>
+      <div style={{ fontSize: '6.5px', color: 'rgba(0,212,255,0.6)', letterSpacing: '0.25em', fontWeight: 700, marginBottom: '12px' }}>BEYBREW · COMBO</div>
+      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '14px' }}>
+        <div style={{ position: 'relative', width: '60px', height: '60px', flexShrink: 0 }}>
+          {blade && BEYBLADE_DB[blade]?.image && (
+            <img src={`/images/${BEYBLADE_DB[blade].image}`} alt={blade}
+              style={{ width: '60px', height: '60px', borderRadius: '50%', objectFit: 'contain', background: '#0f1e2e', border: `2px solid ${ACCENT}80` }}
+            />
+          )}
+          {isCXLine && lockChip && BEYBLADE_DB[lockChip]?.image && (
+            <img src={`/images/${BEYBLADE_DB[lockChip].image}`} alt={lockChip}
+              style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', width: '38%', height: '38%', objectFit: 'contain' }}
+            />
+          )}
+        </div>
+        <div>
+          <div style={{ fontSize: '15px', fontWeight: 900, color: '#fff', lineHeight: 1.2, letterSpacing: '0.02em' }}>{name || '—'}</div>
+          {(spinType || bitType) && (
+            <div style={{ fontSize: '6.5px', color: 'rgba(0,212,255,0.5)', marginTop: '4px', letterSpacing: '0.1em' }}>
+              {[spinType && `${spinType.toUpperCase()} SPIN`, bitType && bitType.toUpperCase()].filter(Boolean).join(' · ')}
+            </div>
+          )}
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {STAT_DEFS.map(({ key, label, gradient, color, limit }) => {
+          const value = stats[key] || 0;
+          const pct = Math.min(100, (value / limit) * 100);
+          return (
+            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <span style={{ fontSize: '6.5px', color: 'rgba(255,255,255,0.35)', letterSpacing: '0.12em', width: '48px', flexShrink: 0 }}>{label}</span>
+              <div style={{ flex: 1, height: '4px', borderRadius: '2px', background: 'rgba(255,255,255,0.07)', overflow: 'hidden' }}>
+                <div style={{ height: '100%', width: `${pct}%`, background: gradient, borderRadius: '2px' }} />
+              </div>
+              <span style={{ fontSize: '6.5px', color, fontWeight: 700, width: '20px', textAlign: 'right' }}>{value}</span>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ marginTop: '14px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,transparent,rgba(255,255,255,0.08))' }} />
+        <span style={{ fontSize: '7px', color: 'rgba(255,255,255,0.2)', letterSpacing: '0.18em', fontWeight: 600 }}>BEYBLADEBREW.COM</span>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,rgba(255,255,255,0.08),transparent)' }} />
+      </div>
+    </div>
+  );
+}
+
+SingleComboWidget.propTypes = { combo: PropTypes.object };
+
+export default SingleComboWidget;

--- a/src/components/widgets/SingleComboWidget.jsx
+++ b/src/components/widgets/SingleComboWidget.jsx
@@ -44,7 +44,7 @@ function SingleComboWidget({ combo }) {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
         {STAT_DEFS.map(({ key, label, gradient, color, limit }) => {
           const value = stats[key] || 0;
-          const pct = Math.min(100, (value / limit) * 100);
+          const pct = Math.min(100, value / limit);
           return (
             <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
               <span style={{ fontSize: '6.5px', color: 'rgba(255,255,255,0.35)', letterSpacing: '0.12em', width: '48px', flexShrink: 0 }}>{label}</span>

--- a/src/hooks/useBeybladeDeck.js
+++ b/src/hooks/useBeybladeDeck.js
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { BEYBLADE_DB } from '../constants';
 import { randomizeBeyblades, randomizeSingleBeyblade } from '../randomize';
 import { parseSharedBeys } from '../lib/comboUtils';
+import { buildShareUrl } from '../lib/shareUrl';
 
 function getPartsUsed(beys) {
   const parts = new Set();
@@ -78,18 +79,9 @@ export function useBeybladeDeck() {
   };
 
   const handleShareButton = () => {
-    const url = new URL(window.location.href);
-    url.searchParams.set('beynum', beybladeCount);
-    url.searchParams.set('format', currentFormat);
-    beyblades.forEach((bey) => {
-      url.searchParams.append(
-        'beys',
-        `${bey.blade},${bey.ratchet},${bey.bit},${bey.assistBlade || ''},${bey.lockChip || ''},${bey.bladeMode || 0},${bey.assistBladeMode || 0},${bey.bitMode || 0}`
-      );
-    });
-
+    const url = buildShareUrl(beyblades, beybladeCount, currentFormat);
     navigator.clipboard
-      .writeText(url.toString())
+      .writeText(url)
       .then(() => window.alert('Successfully copied to clipboard!'))
       .catch((err) => console.error('Failed to copy URL:', err));
   };

--- a/src/hooks/useBeybladeDeck.js
+++ b/src/hooks/useBeybladeDeck.js
@@ -2,22 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { BEYBLADE_DB } from '../constants';
 import { randomizeBeyblades, randomizeSingleBeyblade } from '../randomize';
-
-function parseSharedBeys(rawBeys) {
-  return rawBeys.map((bey) => {
-    const [
-      blade, ratchet, bit,
-      assistBlade = '', lockChip = '',
-      bladeMode = '0', assistBladeMode = '0', bitMode = '0',
-    ] = bey.split(',');
-    return {
-      blade, ratchet, bit, assistBlade, lockChip,
-      bladeMode: Number(bladeMode),
-      assistBladeMode: Number(assistBladeMode),
-      bitMode: Number(bitMode),
-    };
-  });
-}
+import { parseSharedBeys } from '../lib/comboUtils';
 
 function getPartsUsed(beys) {
   const parts = new Set();

--- a/src/lib/comboUtils.js
+++ b/src/lib/comboUtils.js
@@ -1,0 +1,52 @@
+import { BEYBLADE_DB, getStats } from '../constants';
+
+export const STAT_DEFS = [
+  { key: 'attack',          label: 'ATTACK',  gradient: 'linear-gradient(90deg,#1565c0,#00d4ff)', color: '#00d4ff', limit: 2 },
+  { key: 'defense',         label: 'DEFENSE', gradient: 'linear-gradient(90deg,#2e7d32,#00e676)', color: '#00e676', limit: 2 },
+  { key: 'stamina',         label: 'STAMINA', gradient: 'linear-gradient(90deg,#e65100,#ffcc02)', color: '#ffcc02', limit: 2 },
+  { key: 'xDash',           label: 'X-DASH',  gradient: 'linear-gradient(90deg,#b71c1c,#ff6d00)', color: '#ff6d00', limit: 1 },
+  { key: 'burstResistance', label: 'BURST',   gradient: 'linear-gradient(90deg,#4a148c,#aa00ff)', color: '#aa00ff', limit: 1 },
+];
+
+export function parseSharedBeys(rawBeys) {
+  return rawBeys.map((bey) => {
+    const [
+      blade, ratchet, bit,
+      assistBlade = '', lockChip = '',
+      bladeMode = '0', assistBladeMode = '0', bitMode = '0',
+    ] = bey.split(',');
+    return {
+      blade, ratchet, bit, assistBlade, lockChip,
+      bladeMode: Number(bladeMode),
+      assistBladeMode: Number(assistBladeMode),
+      bitMode: Number(bitMode),
+    };
+  });
+}
+
+export function getComboStats(combo) {
+  const { blade, assistBlade, ratchet, bit, bladeMode = 0, assistBladeMode = 0, bitMode = 0 } = combo || {};
+  const bladeStats   = getStats(blade, bladeMode);
+  const assistStats  = getStats(assistBlade, assistBladeMode);
+  const ratchetStats = getStats(ratchet);
+  const bitStats     = getStats(bit, bitMode);
+  return {
+    attack:          (bladeStats.attack || 0) + (assistStats.attack || 0) + (ratchetStats.attack || 0) + (bitStats.attack || 0),
+    defense:         (bladeStats.defense || 0) + (assistStats.defense || 0) + (ratchetStats.defense || 0) + (bitStats.defense || 0),
+    stamina:         (bladeStats.stamina || 0) + (assistStats.stamina || 0) + (ratchetStats.stamina || 0) + (bitStats.stamina || 0),
+    xDash:           bitStats.xDash || 0,
+    burstResistance: bitStats.burstResistance || 0,
+  };
+}
+
+export function getComboName(combo) {
+  const { blade, assistBlade, ratchet, bit, lockChip } = combo || {};
+  const isCXLine = BEYBLADE_DB[blade]?.line === 'CX';
+  return [
+    isCXLine && lockChip ? lockChip : null,
+    blade,
+    isCXLine ? BEYBLADE_DB[assistBlade]?.alias : null,
+    BEYBLADE_DB[ratchet]?.altname,
+    BEYBLADE_DB[bit]?.alias,
+  ].filter(Boolean).join(' ');
+}

--- a/src/lib/shareUrl.js
+++ b/src/lib/shareUrl.js
@@ -1,0 +1,25 @@
+function serializeBey(bey) {
+  return `${bey.blade},${bey.ratchet},${bey.bit},${bey.assistBlade || ''},${bey.lockChip || ''},${bey.bladeMode || 0},${bey.assistBladeMode || 0},${bey.bitMode || 0}`;
+}
+
+export function buildShareUrl(beyblades, beybladeCount, format) {
+  const url = new URL(window.location.origin + window.location.pathname);
+  url.searchParams.set('beynum', beybladeCount);
+  url.searchParams.set('format', format);
+  beyblades.forEach((bey) => url.searchParams.append('beys', serializeBey(bey)));
+  return url.toString();
+}
+
+export function buildEmbedUrl(beyblades, beybladeCount, format, widgetType, comboIndex = 0) {
+  const url = new URL(window.location.origin + window.location.pathname);
+  url.searchParams.set('widget', widgetType);
+  url.searchParams.set('format', format);
+  if (widgetType === 'single') {
+    const bey = beyblades[comboIndex];
+    if (bey) url.searchParams.append('beys', serializeBey(bey));
+  } else {
+    url.searchParams.set('beynum', beybladeCount);
+    beyblades.forEach((bey) => url.searchParams.append('beys', serializeBey(bey)));
+  }
+  return url.toString();
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,23 +1,23 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
-import './index.css'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
 
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router-dom";
+const widgetType = new URLSearchParams(window.location.search).get('widget');
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <App />
-  },
-]);
+async function mount() {
+  if (widgetType) {
+    const { default: EmbedApp } = await import('./EmbedApp.jsx');
+    createRoot(document.getElementById('root')).render(
+      <StrictMode><EmbedApp /></StrictMode>
+    );
+  } else {
+    const { default: App } = await import('./App.jsx');
+    const { createBrowserRouter, RouterProvider } = await import('react-router-dom');
+    const router = createBrowserRouter([{ path: '/', element: <App /> }]);
+    createRoot(document.getElementById('root')).render(
+      <StrictMode><RouterProvider router={router} /></StrictMode>
+    );
+  }
+}
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <RouterProvider router={router} />
-    {/* <App /> */}
-  </StrictMode>,
-)
+mount();


### PR DESCRIPTION
## Summary

- Adds 4 embeddable widget styles (Deck Card, Single Combo, Compact List, Compact with Image) usable as both live `<iframe>` embeds and PNG downloads
- Replaces the Share button with a modal that has **Share Link** and **Embed** tabs — the Embed tab shows a live iframe preview, auto-sized embed code, and a widget type picker
- Upgrades download buttons to **split buttons**: left side downloads with the last-selected style, right side opens a style dropdown
- Adds embed mode via `?widget=` URL param — renders a bare widget with no header or controls, suitable for iframing on any site
- Iframe embed code auto-calculates height based on widget type and combo count, and uses `width="100%"` for responsive embedding

## New files

| File | Purpose |
|------|---------|
| `src/lib/comboUtils.js` | Shared combo utilities (STAT_DEFS, parseSharedBeys, getComboStats, getComboName) |
| `src/lib/shareUrl.js` | URL builders for share links and embed URLs |
| `src/EmbedApp.jsx` | Root for embed mode — reads `?widget=` param, renders matching widget |
| `src/components/ShareModal.jsx` | Share/Embed modal |
| `src/components/widgets/DeckWidget.jsx` | All combos with images and stat bars |
| `src/components/widgets/SingleComboWidget.jsx` | One combo, large image, full stat bars |
| `src/components/widgets/CompactListWidget.jsx` | Numbered combo names, no images |
| `src/components/widgets/CompactImageWidget.jsx` | Small circular image + condensed bars |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Share button opens modal — Share Link tab shows URL + copy works
- [ ] Embed tab: pick each widget style, live preview updates, copy code produces correct `<iframe>` snippet
- [ ] Single Combo style: combo picker appears, switching combos updates preview
- [ ] Download Deck split button: left downloads with current style, chevron opens dropdown with 3 styles
- [ ] Per-combo split button: left downloads single combo, chevron opens dropdown with 2 styles
- [ ] Navigate to `/?widget=deck&beynum=2&beys=Dran+Sword,3-60F,Flat&beys=Cobalt+Dragoon,4-80B,Bound` — only the widget renders (no header/controls)
- [ ] All 4 `?widget=` values render correctly: `deck`, `single`, `compact`, `compact-image`
- [ ] Stat bars show correct fill (not always-full)

🤖 Generated with [Claude Code](https://claude.com/claude-code)