### PR TITLE
feat: add Story (9:16) export for Instagram/Facebook Stories

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import DeckWidget from './components/widgets/DeckWidget';
 import SingleComboWidget from './components/widgets/SingleComboWidget';
 import CompactListWidget from './components/widgets/CompactListWidget';
 import CompactImageWidget from './components/widgets/CompactImageWidget';
+import StoryComboWidget from './components/widgets/StoryComboWidget';
 import { shouldShowSupportPopup } from './lib/supportPopup';
 import { useBeybladeDeck } from './hooks/useBeybladeDeck';
 
@@ -176,18 +177,26 @@ function App() {
     setComboExportStyle(resolvedStyle);
     setIsDownloading(true);
 
+    const isStory = resolvedStyle === 'story';
     const container = document.createElement('div');
-    container.style.cssText = 'position:fixed;left:-9999px;top:0;width:320px';
+    container.style.cssText = isStory
+      ? 'position:fixed;left:-9999px;top:0;width:540px;height:960px'
+      : 'position:fixed;left:-9999px;top:0;width:320px';
     document.body.appendChild(container);
     const root = createRoot(container);
     flushSync(() => root.render(
-      resolvedStyle === 'single'
-        ? <SingleComboWidget combo={beyblades[index]} />
-        : <CompactImageWidget combos={[beyblades[index]]} beybladeCount={1} format={currentFormat} />
+      resolvedStyle === 'story'
+        ? <StoryComboWidget combo={beyblades[index]} />
+        : resolvedStyle === 'single'
+          ? <SingleComboWidget combo={beyblades[index]} />
+          : <CompactImageWidget combos={[beyblades[index]]} beybladeCount={1} format={currentFormat} />
     ));
-    domToPng(container, { backgroundColor: '#080c18', scale: 3 })
+    domToPng(container, { backgroundColor: '#080c18', scale: isStory ? 4 : 3 })
       .then((dataUrl) => {
-        download(dataUrl, `beybrew_combo${index + 1}_${Date.now()}.png`, 'image/png');
+        const filename = isStory
+          ? `beybrew_story_combo${index + 1}_${Date.now()}.png`
+          : `beybrew_combo${index + 1}_${Date.now()}.png`;
+        download(dataUrl, filename, 'image/png');
       })
       .catch(() => setDownloadError('Download failed. Try again.'))
       .finally(() => {
@@ -443,6 +452,7 @@ function App() {
                           {[
                             { id: 'single',        label: 'Single Combo',       desc: 'Large image, full bars' },
                             { id: 'compact-image', label: 'Compact with Image', desc: 'Small image + bars' },
+                            { id: 'story',         label: 'Story (9:16)',        desc: 'Instagram / Facebook Stories' },
                           ].map(({ id, label, desc }) => (
                             <button key={id}
                               onClick={() => { setShowComboStyleMenu(null); handleDownloadCombo(index, id); }}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import SingleComboWidget from './components/widgets/SingleComboWidget';
 import CompactListWidget from './components/widgets/CompactListWidget';
 import CompactImageWidget from './components/widgets/CompactImageWidget';
 import StoryComboWidget from './components/widgets/StoryComboWidget';
+import StoryDeckWidget from './components/widgets/StoryDeckWidget';
 import { shouldShowSupportPopup } from './lib/supportPopup';
 import { useBeybladeDeck } from './hooks/useBeybladeDeck';
 
@@ -149,20 +150,28 @@ function App() {
     setDeckExportStyle(resolvedStyle);
     setIsDownloading(true);
 
+    const isStory = resolvedStyle === 'story';
     const container = document.createElement('div');
-    container.style.cssText = 'position:fixed;left:-9999px;top:0;width:480px';
+    container.style.cssText = isStory
+      ? 'position:fixed;left:-9999px;top:0;width:540px;height:960px'
+      : 'position:fixed;left:-9999px;top:0;width:480px';
     document.body.appendChild(container);
     const root = createRoot(container);
     flushSync(() => root.render(
-      resolvedStyle === 'compact'
-        ? <CompactListWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
-        : resolvedStyle === 'compact-image'
-          ? <CompactImageWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
-          : <DeckWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+      resolvedStyle === 'story'
+        ? <StoryDeckWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+        : resolvedStyle === 'compact'
+          ? <CompactListWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+          : resolvedStyle === 'compact-image'
+            ? <CompactImageWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
+            : <DeckWidget combos={beyblades} beybladeCount={beybladeCount} format={currentFormat} />
     ));
-    domToPng(container, { backgroundColor: '#080c18', scale: 3 })
+    domToPng(container, { backgroundColor: '#080c18', scale: isStory ? 4 : 3 })
       .then((dataUrl) => {
-        download(dataUrl, `beybrew_deck_${Date.now()}.png`, 'image/png');
+        const filename = isStory
+          ? `beybrew_story_deck_${Date.now()}.png`
+          : `beybrew_deck_${Date.now()}.png`;
+        download(dataUrl, filename, 'image/png');
       })
       .catch(() => setDownloadError('Download failed. Try again.'))
       .finally(() => {
@@ -647,6 +656,7 @@ function App() {
                     { id: 'deck',          label: 'Deck Card',         desc: 'All combos, images, bars' },
                     { id: 'compact',       label: 'Compact List',       desc: 'Names only' },
                     { id: 'compact-image', label: 'Compact with Image', desc: 'Small image + bars' },
+                    { id: 'story',         label: 'Story (9:16)',        desc: 'Instagram / Facebook Stories' },
                   ].map(({ id, label, desc }) => (
                     <button key={id}
                       onClick={() => { setShowDeckStyleMenu(false); handleDownloadDeck(id); }}

--- a/src/components/widgets/StoryComboWidget.jsx
+++ b/src/components/widgets/StoryComboWidget.jsx
@@ -62,7 +62,7 @@ function StoryComboWidget({ combo }) {
       <div style={{ height: '1px', background: 'linear-gradient(90deg,transparent,rgba(0,212,255,0.3),transparent)', margin: '20px 0', flexShrink: 0 }} />
 
       {/* Combo name */}
-      <div style={{ fontSize: '28px', fontWeight: 900, color: '#fff', lineHeight: 1.1, letterSpacing: '0.02em', marginBottom: '10px', flexShrink: 0 }}>
+      <div style={{ fontSize: '28px', fontWeight: 900, color: '#fff', lineHeight: 1.1, letterSpacing: '0.02em', marginBottom: '10px', flexShrink: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
         {name || '—'}
       </div>
 

--- a/src/components/widgets/StoryComboWidget.jsx
+++ b/src/components/widgets/StoryComboWidget.jsx
@@ -86,12 +86,12 @@ function StoryComboWidget({ combo }) {
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: '14px' }}>
         {STAT_DEFS.map(({ key, label, gradient, color, limit }) => {
           const value = stats[key] || 0;
-          const pct = Math.min(1, value / limit);
+          const pct = Math.min(100, value / limit);
           return (
             <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
               <span style={{ fontSize: '10px', color: 'rgba(255,255,255,0.35)', letterSpacing: '0.12em', width: '80px', flexShrink: 0 }}>{label}</span>
               <div style={{ flex: 1, height: '6px', borderRadius: '3px', background: 'rgba(255,255,255,0.07)', overflow: 'hidden' }}>
-                <div style={{ height: '100%', width: `${pct * 100}%`, background: gradient, borderRadius: '3px' }} />
+                <div style={{ height: '100%', width: `${pct}%`, background: gradient, borderRadius: '3px' }} />
               </div>
               <span style={{ fontSize: '13px', color, fontWeight: 700, width: '28px', textAlign: 'right' }}>{value}</span>
             </div>

--- a/src/components/widgets/StoryDeckWidget.jsx
+++ b/src/components/widgets/StoryDeckWidget.jsx
@@ -1,0 +1,151 @@
+import PropTypes from 'prop-types';
+import { BEYBLADE_DB, LIMITED_FORMAT } from '../../constants';
+import { getComboStats, getComboName, STAT_DEFS } from '../../lib/comboUtils';
+
+const ACCENT_COLORS = ['#00d4ff', '#7b61ff', '#ffa040'];
+const DOT_BG = {
+  backgroundImage: 'radial-gradient(rgba(0,212,255,0.06) 1px, transparent 1px)',
+  backgroundSize: '24px 24px',
+};
+
+function ComboSection({ combo, accent, imageSize, statHeight, statGap, nameFontSize }) {
+  const { blade, lockChip } = combo || {};
+  const isCXLine = BEYBLADE_DB[blade]?.line === 'CX';
+  const stats = getComboStats(combo);
+  const name = getComboName(combo);
+
+  return (
+    <div style={{
+      flex: 1,
+      background: `${accent}08`,
+      border: `1px solid ${accent}22`,
+      borderLeft: `3px solid ${accent}`,
+      borderRadius: '10px',
+      padding: '10px 12px',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      overflow: 'hidden',
+      minHeight: 0,
+    }}>
+      {imageSize > 0 && (
+        <div style={{ position: 'relative', width: `${imageSize}px`, height: `${imageSize}px`, flexShrink: 0 }}>
+          {blade && BEYBLADE_DB[blade]?.image ? (
+            <img
+              src={`/images/${BEYBLADE_DB[blade].image}`}
+              alt={blade}
+              style={{ width: `${imageSize}px`, height: `${imageSize}px`, borderRadius: '50%', objectFit: 'contain', background: '#0f1e2e', border: `2px solid ${accent}80` }}
+            />
+          ) : (
+            <div style={{ width: `${imageSize}px`, height: `${imageSize}px`, borderRadius: '50%', background: '#0f1e2e', border: `2px solid ${accent}80` }} />
+          )}
+          {isCXLine && lockChip && BEYBLADE_DB[lockChip]?.image && (
+            <img
+              src={`/images/${BEYBLADE_DB[lockChip].image}`}
+              alt={lockChip}
+              style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', width: '38%', height: '38%', objectFit: 'contain' }}
+            />
+          )}
+        </div>
+      )}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: `${nameFontSize}px`, fontWeight: 800, color: '#fff', marginBottom: `${statGap}px`, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {name || '—'}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: `${Math.max(2, statGap - 2)}px` }}>
+          {STAT_DEFS.map(({ key, label, gradient, color, limit }) => {
+            const value = stats[key] || 0;
+            const pct = Math.min(100, value / limit);
+            return (
+              <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <span style={{ fontSize: '7px', color: 'rgba(255,255,255,0.3)', letterSpacing: '0.1em', width: '44px', flexShrink: 0 }}>{label}</span>
+                <div style={{ flex: 1, height: `${statHeight}px`, borderRadius: '2px', background: 'rgba(255,255,255,0.07)', overflow: 'hidden' }}>
+                  <div style={{ height: '100%', width: `${pct}%`, background: gradient, borderRadius: '2px' }} />
+                </div>
+                <span style={{ fontSize: '8px', color, fontWeight: 700, width: '16px', textAlign: 'right' }}>{value}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ComboSection.propTypes = {
+  combo: PropTypes.object,
+  accent: PropTypes.string.isRequired,
+  imageSize: PropTypes.number.isRequired,
+  statHeight: PropTypes.number.isRequired,
+  statGap: PropTypes.number.isRequired,
+  nameFontSize: PropTypes.number.isRequired,
+};
+
+function StoryDeckWidget({ combos, beybladeCount, format }) {
+  const formatLabel = format === LIMITED_FORMAT ? 'LIMITED' : 'STANDARD';
+
+  let imageSize, statHeight, statGap, nameFontSize;
+  if (beybladeCount <= 3) {
+    imageSize = 100; statHeight = 5; statGap = 8; nameFontSize = 13;
+  } else if (beybladeCount <= 6) {
+    imageSize = 64; statHeight = 4; statGap = 5; nameFontSize = 11;
+  } else {
+    imageSize = 0; statHeight = 3; statGap = 4; nameFontSize = 10;
+  }
+
+  return (
+    <div style={{
+      ...DOT_BG,
+      background: '#080c18',
+      width: '540px',
+      height: '960px',
+      fontFamily: 'system-ui,-apple-system,sans-serif',
+      display: 'flex',
+      flexDirection: 'column',
+      padding: '28px 32px',
+      boxSizing: 'border-box',
+      overflow: 'hidden',
+    }}>
+      {/* Header */}
+      <div style={{ textAlign: 'center', marginBottom: '20px', flexShrink: 0 }}>
+        <div style={{ fontSize: '26px', fontWeight: 900, letterSpacing: '0.08em', background: 'linear-gradient(90deg,#00d4ff,#7b61ff)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', backgroundClip: 'text' }}>
+          BEYBREW
+        </div>
+        <div style={{ width: '60px', height: '1px', background: 'linear-gradient(90deg,transparent,#00d4ff,transparent)', margin: '6px auto' }} />
+        <div style={{ fontSize: '9px', color: 'rgba(0,212,255,0.7)', letterSpacing: '0.22em', fontWeight: 600 }}>
+          BEYBLADE X DECK · {formatLabel}
+        </div>
+      </div>
+
+      {/* Combos */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '10px', overflow: 'hidden', minHeight: 0 }}>
+        {Array(beybladeCount).fill(null).map((_, i) => (
+          <ComboSection
+            key={i}
+            combo={combos[i]}
+            accent={ACCENT_COLORS[i % ACCENT_COLORS.length]}
+            imageSize={imageSize}
+            statHeight={statHeight}
+            statGap={statGap}
+            nameFontSize={nameFontSize}
+          />
+        ))}
+      </div>
+
+      {/* Watermark */}
+      <div style={{ marginTop: '16px', display: 'flex', alignItems: 'center', gap: '10px', flexShrink: 0 }}>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,transparent,rgba(255,255,255,0.08))' }} />
+        <span style={{ fontSize: '9px', color: 'rgba(255,255,255,0.2)', letterSpacing: '0.18em', fontWeight: 600 }}>BEYBLADEBREW.COM</span>
+        <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg,rgba(255,255,255,0.08),transparent)' }} />
+      </div>
+    </div>
+  );
+}
+
+StoryDeckWidget.propTypes = {
+  combos: PropTypes.array.isRequired,
+  beybladeCount: PropTypes.number.isRequired,
+  format: PropTypes.string,
+};
+
+export default StoryDeckWidget;


### PR DESCRIPTION
## Summary

- Add `StoryComboWidget` — single combo in 9:16 hero layout (large blade image, combo name, type tags, all 5 stat bars)
- Add `StoryDeckWidget` — full deck in 9:16 canvas, stacked combos with density tiers (1–3 large, 4–6 medium, 7–10 compact)
- Wire both into existing download dropdowns as **Story (9:16)** option — per-combo and deck download menus

Exports produce 2160×3840 PNG (4× 540×960 render), the ideal size for Instagram and Facebook Stories.

## Test Plan

- [ ] Select a blade/ratchet/bit, open per-combo download dropdown, click **Story (9:16)** — verify PNG is 2160×3840 with blade image in upper portion, combo name, 5 stat bars, and watermark
- [ ] Test with a CX-line blade — verify lock chip overlays the center of the blade image
- [ ] Set deck to 3 combos, download deck as Story (9:16) — verify 3 combo rows with full images
- [ ] Set deck to 6 combos — verify smaller images, all combos fit
- [ ] Set deck to 8 combos — verify no images, name + stat bars only, all 8 fit without overflow
- [ ] Verify existing export styles (Single Combo, Compact, Deck Card) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)